### PR TITLE
Ignore routes with no 'uses'

### DIFF
--- a/src/Autoroute.php
+++ b/src/Autoroute.php
@@ -76,7 +76,11 @@ class Autoroute
                 $uses = $this->namer->getUses($options);
                 $options = compact('uses');
             } else {
-                $uses = $options['uses'];
+                $uses = $options['uses'] ?? null;
+            }
+            
+            if (!$uses) {
+                continue;
             }
 
             // Create route


### PR DESCRIPTION
I am trying to combine `laravel-autoroute` with `zircote/swagger-php` but ran into an issue for paths with variables. 

Error:
```
In Autoroute.php line 79:
Undefined index: uses
```

Data:
```
...
  paths:
    "/user/{id}":
      where:
        id: '[0-9]+'
      parameters:
        - name: id
          in: path
          required: true
          schema:
            type: string
            pattern: '[0-9]+'
      get:
        description: Returns the user data based on ID
        uses: UserController@index
        responses:
          '200':
            description: user response.
...
```

The `parameters` variable causes the error because it doesn't have a `uses`. 

![Screenshot_2020-11-02 Swagger UI](https://user-images.githubusercontent.com/1240252/97890324-514e1800-1d25-11eb-8b58-4f23b4bfa12a.png)